### PR TITLE
Update ms slugs

### DIFF
--- a/da-105-monsterbekquaestiones-projectdata.xml
+++ b/da-105-monsterbekquaestiones-projectdata.xml
@@ -10,7 +10,7 @@
     <textfilesdir>https://github.com/mldac/monsterbek_questiones.git</textfilesdir> <!-- if bitbucket repo was public this could be bitbukcet base -->
     <hasWitnesses>
       <witness id="K">
-        <slug>kra</slug>
+        <slug>krajag1578</slug>
         <title>Krakow, Biblioteka Jagiellonska 1578, ff. 2ra--34vb</title>
         <initial>O</initial>
       </witness>

--- a/da-236-hispanussententia-projectdata.xml
+++ b/da-236-hispanussententia-projectdata.xml
@@ -29,7 +29,7 @@
     -->
   	<hasWitnesses>
       <witness id="K">
-        <slug>kra726</slug>
+        <slug>krajag726</slug>
         <questionTitle>Kraków, Biblioteka Jagiellońska, ms. 726</questionTitle>
         <initial>K</initial>
       	<canvasBase>http://scta.info/iiif/kra726/canvas/</canvasBase>

--- a/da-263-aegidiustractatus-projectdata.xml
+++ b/da-263-aegidiustractatus-projectdata.xml
@@ -10,7 +10,7 @@
     <textfilesdir>https://github.com/mldac/aer-trip.git</textfilesdir> <!-- if bitbucket repo was public this could be bitbukcet base -->
     <hasWitnesses>
       <witness id="O">
-        <slug>oxf</slug>
+        <slug>boddig150</slug>
         <title>Oxford, Bodleian Library, Digby 150, ff. 132v-144v</title>
         <initial>O</initial>
         <folio>132vb-144vb</folio>

--- a/da-3-hedonensistractatus-projectdata.xml
+++ b/da-3-hedonensistractatus-projectdata.xml
@@ -14,12 +14,12 @@
     <questionListEncoder>Michael Stenskjær Christensen</questionListEncoder>
     <hasWitnesses>
       <witness id="C">
-        <slug>cam342</slug>
+        <slug>goncai342</slug>
         <title>Cambridge, Gonville & Caius College, 342/538</title>
         <initial>C</initial>
       </witness>
       <witness id="O">
-        <slug>oxf107</slug>
+        <slug>corchr107</slug>
         <title>Oxford, Corpus Christi College Library, 107</title>
         <initial>O</initial>
       </witness>

--- a/da-57-alexanderexpositio-projectdata.xml
+++ b/da-57-alexanderexpositio-projectdata.xml
@@ -10,7 +10,7 @@
     <textfilesdir>https://github.com/mldac/alexanderexpositio.git</textfilesdir> <!-- if bitbucket repo was public this could be bitbukcet base -->
     <hasWitnesses>
       <witness id="A">
-        <slug>ass</slug>
+        <slug>assfra326</slug>
         <title>Assisi, Biblioteca Convento di San Francesco 326, ff. 1--92v</title>
         <initial>A</initial>
       </witness>


### PR DESCRIPTION
I have made the changes as you suggested.

I think its a good idea to make the slugs a bit longer to make it
easier to make them unique. Now I have composed the slugs of six
characters from the manuscript location (favouring colleges over towns
when relevant) and the ms number.

Another possibility would be to use the last 8 characters of the SHA-1
hash of the ms. name (town, library, shelfmark, number). But this should
work for now.